### PR TITLE
Fix duplicate output to POT file

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,15 +5,15 @@ var deepExtend = require('deep-extend');
 var reactGettextParser = require('react-gettext-parser');
 
 module.exports = function(babel) {
-  console.log(babel);
+  //console.log(babel);
   var allMessages = [];
 
   var traverser = reactGettextParser.getTraverser(function(messages, state) {
     console.log('got messages', messages);
-    allMessages = allMessages.concat(messages);
+    allMessages = reactGettextParser.getUniqueBlocks(allMessages.concat(messages));
 
     reactGettextParser.outputPot(
-      state.opts.target,
+      state.opts.target || state.opts.output,
       reactGettextParser.toPot(allMessages)
     );
   });


### PR DESCRIPTION
`babel --plugins react-gettext-parser src/*.js` used to output duplicates (duplicates as in the exact same lines from the same locations are repeated over and over with each new transpiled file) to the POT file. This PR fixes the unwanted behavior.
